### PR TITLE
Implement Example: How to determine if a slice is empty

### DIFF
--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -24,56 +24,37 @@ contract HelloWorld {
 
 Use `empty()` method to check if `slice` is empty.
 
-To check if slice `data` is empty, use `dataEmpty()` method.
-
-To check if slice `refs` is empty, use `refsEmpty()` method.
-
 ```tact
 // Create an empty slice with no data and no refs
 let empty_slice: Slice = emptyCell().asSlice();
-
-empty_slice.dataEmpty(); // returns `true`
-empty_slice.refsEmpty(); // returns `true`
-empty_slice.empty();     // returns `true` 
-
+// Returns `true`, because slice doesn't have any `bits` and `refs`
+empty_slice.empty();
 
 // Create a slice with some data
 let slice_with_data: Slice = beginCell().
     storeUint(42, 8).
     asSlice();
-
-slice_with_data.dataEmpty(); // returns `false`
-slice_with_data.refsEmpty(); // returns `true`
-slice_with_data.empty();     // returns `false` 
-
+// Returns `false`, because slice have any `data`
+slice_with_data.empty();
 
 // Create a slice with reference to empty cell
 let slice_with_refs: Slice  = beginCell().
     storeRef(emptyCell()).
     asSlice();
-
-slice_with_refs.dataEmpty(); // returns `true`
-slice_with_refs.refsEmpty(); // returns `false`
-slice_with_refs.empty();     // returns `false` 
+// Returns `false`, because slice have any `refs`
+slice_with_refs.empty();
 
 
+// Create a slice with data and reference
 let slice_with_data_and_refs: Slice  = beginCell().
     storeUint(42, 8).
     storeRef(emptyCell()).
     asSlice();
-
-slice_with_data_and_refs.dataEmpty(); // returns `false`
-slice_with_data_and_refs.refsEmpty(); // returns `false`
-slice_with_data_and_refs.empty();     // returns `false` 
+// Returns `false`, because slice have any `data` and `refs`
+slice_with_data_and_refs.empty(); 
 ```
 
 💡 Useful links
-
 - [`empty()` in docs](https://docs.tact-lang.org/language/ref/cells#sliceempty)
 - [`dataEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicedataempty)
 - [`refsEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicerefsempty)
-
-👀 See also
-
-- ["Get number of references" in docs](https://docs.tact-lang.org/language/ref/cells#slicerefs)
-- ["Get number of data bits" in docs](https://docs.tact-lang.org/language/ref/cells#slicebits)

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -44,7 +44,6 @@ let slice_with_refs: Slice  = beginCell().
 // Returns `false`, because slice have any `refs`
 slice_with_refs.empty();
 
-
 // Create a slice with data and reference
 let slice_with_data_and_refs: Slice  = beginCell().
     storeUint(42, 8).
@@ -58,3 +57,4 @@ slice_with_data_and_refs.empty();
 - [`empty()` in docs](https://docs.tact-lang.org/language/ref/cells#sliceempty)
 - [`dataEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicedataempty)
 - [`refsEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicerefsempty)
+- [`emptyCell()` in docs](https://docs.tact-lang.org/language/ref/cells#emptycell)

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -22,34 +22,34 @@ contract HelloWorld {
 
 `Slice` is considered *empty* if it has no stored `data` **and** no stored `references`.
 
-Use `empty()` method to check if `slice` is empty.
+Use `empty()` method to check if a `slice` is empty.
 
 ```tact
 // Create an empty slice with no data and no refs
 let empty_slice: Slice = emptyCell().asSlice();
-// Returns `true`, because slice doesn't have any `bits` and `refs`
+// Returns `true`, because `empty_slice` doesn't have any data or refs
 empty_slice.empty();
 
 // Create a slice with some data
 let slice_with_data: Slice = beginCell().
     storeUint(42, 8).
     asSlice();
-// Returns `false`, because slice have any `data`
+// Returns `false`, because the slice has some data
 slice_with_data.empty();
 
-// Create a slice with reference to empty cell
+// Create a slice with a reference to an empty cell
 let slice_with_refs: Slice  = beginCell().
     storeRef(emptyCell()).
     asSlice();
-// Returns `false`, because slice have any `refs`
+// Returns `false`, because the slice has a reference
 slice_with_refs.empty();
 
-// Create a slice with data and reference
+// Create a slice with data and a reference
 let slice_with_data_and_refs: Slice  = beginCell().
     storeUint(42, 8).
     storeRef(emptyCell()).
     asSlice();
-// Returns `false`, because slice have any `data` and `refs`
+// Returns `false`, because the slice has both data and reference
 slice_with_data_and_refs.empty(); 
 ```
 

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -17,6 +17,7 @@ contract HelloWorld {
 }
 ```
 
+## Slice
 ### How to determine if slice is empty
 
 `Slice` is considered *empty* if it has no stored `data` **and** no stored `references`.

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -17,3 +17,62 @@ contract HelloWorld {
 }
 ```
 
+### How to determine if slice is empty
+
+`Slice` is considered *empty* if it has no stored `data` **and** no stored `references`.
+
+Use `empty()` method to check if `slice` is empty.
+
+To check if slice `data` is empty, use `dataEmpty()` method.
+
+To check if slice `refs` is empty, use `refsEmpty()` method.
+
+```tact
+// Create an empty slice with no data and no refs
+let empty_slice: Slice = emptyCell().asSlice();
+
+empty_slice.dataEmpty(); // returns `true`
+empty_slice.refsEmpty(); // returns `true`
+empty_slice.empty();     // returns `true` 
+
+
+// Create a slice with some data
+let slice_with_data: Slice = beginCell().
+    storeUint(42, 8).
+    asSlice();
+
+slice_with_data.dataEmpty(); // returns `false`
+slice_with_data.refsEmpty(); // returns `true`
+slice_with_data.empty();     // returns `false` 
+
+
+// Create a slice with reference to empty cell
+let slice_with_refs: Slice  = beginCell().
+    storeRef(emptyCell()).
+    asSlice();
+
+slice_with_refs.dataEmpty(); // returns `true`
+slice_with_refs.refsEmpty(); // returns `false`
+slice_with_refs.empty();     // returns `false` 
+
+
+let slice_with_data_and_refs: Slice  = beginCell().
+    storeUint(42, 8).
+    storeRef(emptyCell()).
+    asSlice();
+
+slice_with_data_and_refs.dataEmpty(); // returns `false`
+slice_with_data_and_refs.refsEmpty(); // returns `false`
+slice_with_data_and_refs.empty();     // returns `false` 
+```
+
+💡 Useful links
+
+- [`empty()` in docs](https://docs.tact-lang.org/language/ref/cells#sliceempty)
+- [`dataEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicedataempty)
+- [`refsEmpty()` in docs](https://docs.tact-lang.org/language/ref/cells#slicerefsempty)
+
+👀 See also
+
+- ["Get number of references" in docs](https://docs.tact-lang.org/language/ref/cells#slicerefs)
+- ["Get number of data bits" in docs](https://docs.tact-lang.org/language/ref/cells#slicebits)


### PR DESCRIPTION
Hi!

I would like to start with a discussion :)

In my opinion, the section about slice emptiness in the FunC cookbook (if we use it as a reference point) is burdened with unnecessary copy-pasting. In this book, there are three very similar sections:

- [How to determine if a slice is empty](https://docs.ton.org/develop/func/cookbook#how-to-determine-if-slice-is-empty)
- [How to determine if a slice is empty (doesn't have any bits, but may have refs)](https://docs.ton.org/develop/func/cookbook#how-to-determine-if-slice-is-empty-dosent-have-any-bits-but-may-have-refs)
- [How to determine if a slice is empty (doesn't have any refs, but may have bits)](https://docs.ton.org/develop/func/cookbook#how-to-determine-if-slice-is-empty-dosent-have-any-bits-but-may-have-refs)

They contain almost the same 26 lines of code, differing only in the use of `empty` / `refsEmpty` / `dataEmpty` calls. I suggest consolidating this into one section that covers all functions at once. The topic is not so complex, so in my opinion, it's better to write an informative comment about the differences between empty/refsEmpty/dataEmpty than to copy-paste.

If you don't like this idea, I can rewrite it in the style of the FunC cookbook.

I also made some minor stylistic changes compared to FunC, like *Useful links* content and new *See Also* content. If there are any issues with this, I'm happy to adhere to a specific standard.

Thank you!

P.S. telegram t.me/aandrukhovich