### PR TITLE
added example of send() with two modes

### DIFF
--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -5,15 +5,14 @@ The core reason for creating the Tact Cookbook is to collect all the experience 
 Compared to the FunC Documentation, this article is more focused on everyday tasks every FunC developer resolve during the development of smart contracts.
 
 ## Basics
-### How to write a Hello World smart contract
+### How to send a message with the entire balance
+If we need to send the entire balance of the smart contract, then, in this case, we need to use send mode 128. Another way we can use the mode SendRemainingBalance, which means the same thing.
 
 ```
-contract HelloWorld {
-
-    get fun greeting(): String {
-        return "hello world";
-    }        
-
-}
+send(SendParameters{
+        to: ctx.sender, 
+        value: 0, 
+        mode: 128 // or SendRemainingBalance
+        bounce: true
+    });
 ```
-


### PR DESCRIPTION
Useful links about mode functionality:

https://docs.ton.org/develop/func/cookbook#how-to-send-a-message-with-the-entire-balance
https://docs.tact-lang.org/language/ref/message-modes