### PR TITLE
Implement Example: How to send a message with a long text comment #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# tact-cookbook
-The core reason for creating the Tact Cookbook is to collect all the experience from Tact developers in one place so that future developers will use it!
+
+# Tact Cookbook 📖
+
+Welcome to the Tact Cookbook! Here, you'll find a collection of practical examples showcasing various functionalities of Tact. Whether you're a beginner just starting out or an experienced developer looking for some inspiration, this cookbook is for you!
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [How to Use This Cookbook](#how-to-use-this-cookbook)
+3. [Examples](#examples)
+4. [Contributing](#contributing)
+5. [Join Our Community](#join-our-community)
+
+---
+
+## Introduction
+
+This cookbook aims to provide bite-sized, easy-to-follow examples that highlight its different capabilities. By working through these examples, you can get a hands-on understanding of how to use Tact effectively.
+> [Example](https://docs.ton.org/develop/func/cookbook) cookbook on FunC
+---
+
+## How to Use This Cookbook
+
+1. **Browse & Select**: Navigate through the list of examples and pick one that interests you.
+2. **Read & Understand**: Each example comes with a detailed explanation of the functionality and the logic behind it.
+3. **Try it Out**: Implement the example in your own Tact environment. Experiment with it, tweak it, and make it your own!
+
+---
+
+## Examples
+
+For a comprehensive list of examples and their explanations, refer to the [tact-cookbook.md](./tact-cookbook.md) file.
+
+---
+
+## Contributing
+
+We welcome contributions from the community! Here's how you can contribute:
+
+1. **Pick an Example**: Visit [this list](https://github.com/alefmanvladimir/tact-cookbook/issues) to choose an example that you'd like to implement. If it's already taken, consider improving existing examples or suggesting a new one.
+2. **Fork this Repository**: Get your own version of the Tact Cookbook.
+3. **Create a New Branch**: Name it appropriately based on the example you're working on.
+4. **Add Your Implementation**: Add your example along with a detailed explanation.
+5. **Create a Pull Request**: Once done, share your changes with us by creating a pull request.
+
+---
+
+## Join Our Community
+
+Passionate about Tact and the examples in this cookbook? We invite you to join the Hack-TON-Berfest [Telegram group](https://t.me/hack_ton_berfest_2023). Connect with other enthusiasts, share your thoughts, and contribute to the broader conversation.
+
+---
+
+
+Happy coding with Tact! 🚀

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -7,11 +7,11 @@ Compared to the FunC Documentation, this article is more focused on everyday tas
 ## Basics
 ### How to send a message with a long text comment
 
-If we need to send a message with a long text comment, we should build a string that consist more than `127` chars. For this we can use the primivite type `StringBuilder` and it's methods `beginComment()` and `append`. Before sending, we should convert this string into the cell with `toCell()` method.
+If we need to send a message with a lengthy text comment, we should create a string that consists of more than `127` characters. To do this, we can utilize the `StringBuilder` primitive type and its methods called `beginComment()` and `append()`. Prior to sending, we should convert this string into a cell using the toCell() method.
 
 ```
 let comment: StringBuilder = beginComment();
-let longString = '...' // some string with amount of chars more than 127
+let longString = '...' // Some string with more than 127 characters.
 str_builder.append(longString);
 
 send(SendParameters{

--- a/tact-cookbook.md
+++ b/tact-cookbook.md
@@ -1,0 +1,31 @@
+# Tact Cookbook
+
+The core reason for creating the Tact Cookbook is to collect all the experience from Tact developers in one place so that future developers will use it!
+
+Compared to the FunC Documentation, this article is more focused on everyday tasks every FunC developer resolve during the development of smart contracts.
+
+## Basics
+### How to send a message with a long text comment
+
+If we need to send a message with a long text comment, we should build a string that consist more than `127` chars. For this we can use the primivite type `StringBuilder` and it's methods `beginComment()` and `append`. Before sending, we should convert this string into the cell with `toCell()` method.
+
+```
+let comment: StringBuilder = beginComment();
+let longString = '...' // some string with amount of chars more than 127
+str_builder.append(longString);
+
+send(SendParameters{
+    to: ctx.sender, 
+    value: 0, 
+    mode: SendIgnoreErrors,
+    body: longString.toCell(),
+    bounce: true,
+});
+```
+
+💡 Useful links
+
+- ["Sending messages" in docs](https://docs.tact-lang.org/language/guides/send#send-message)
+- ["String builder" in docs](https://docs.tact-lang.org/language/guides/types#primitive-types)
+- ["Cell" in docs](https://docs.tact-lang.org/language/ref/cells)
+


### PR DESCRIPTION
Regardless of the limit for 127 chars in a cell described in [FunC docs](https://docs.ton.org/develop/func/cookbook#how-to-send-a-message-with-a-long-text-comment), I successfully compiled the contract and tried it in a [testnet](https://testnet.tonscan.org/tx/x7ONC3E_JwnhwqMaiBnLV6EEg3Rk-vCIAv_94XEg5Uw=) and got a comment of 139 characters length

tg - @gavrisalive